### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "acn-protocol"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acn-protocol"
 description = "ACN protocol written in Rust"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `acn-protocol`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `acn-protocol` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AcnError::InvalidData, previously in file /tmp/.tmpkzDOR9/acn-protocol/src/error.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).